### PR TITLE
Link to repository table in documentation repository (README change only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,38 +155,33 @@ become part of its developer community.
 
 ## Repositories
 
-| Repository          | Description                                                           |
-| ------------------- | --------------------------------------------------------------------- |
-| [cwa-documentation] | Project overview, general documentation, and white papers.            |
-| [cwa-app-ios]       | Native iOS app using the Apple/Google exposure notification API.      |
-| [cwa-app-android]   | Native Android app using the Apple/Google exposure notification API.  |
-| [cwa-wishlist]      | Community feature requests.                                           |
-| [cwa-website]       | The official website for the Corona-Warn-App                          |
-| [cwa-server]        | Backend implementation for the Apple/Google exposure notification API.|
-| [cwa-verification-server] | Backend implementation of the verification process.             |
-| [cwa-verification-portal] | The portal to interact with the verification server             |
-| [cwa-verification-iam]    | The identity and access management to interact with the verification server |
-| [cwa-testresult-server]   | Receives the test results from connected laboratories           |
+| Repository                | Description                                                                  |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| [cwa-documentation]       | Project overview, general documentation, and white papers.                   |
+| [cwa-app-ios]             | Native iOS app using the Apple/Google exposure notification API.             |
+| [cwa-app-android]         | Native Android app using the Apple/Google exposure notification API.         |
+| [cwa-wishlist]            | Community feature requests.                                                  |
+| [cwa-website]             | The official website for the Corona-Warn-App.                                |
+| [cwa-server]              | Backend implementation for the Apple/Google exposure notification API.       |
+| [cwa-ppa-server]          | Backend implementation for the privacy-preserving analytics server.          |
+| [cwa-verification-server] | Backend implementation of the verification process.                          |
+| [cwa-verification-portal] | The portal to interact with the verification server.                         |
+| [cwa-verification-iam]    | The identity and access management to interact with the verification server. |
+| [cwa-testresult-server]   | Receives the test results from connected laboratories.                       |
+| [cwa-log-upload]          | The log upload service is the counterpart of the log upload in the app.      |
 
 [cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation
-
 [cwa-app-ios]: https://github.com/corona-warn-app/cwa-app-ios
-
 [cwa-app-android]: https://github.com/corona-warn-app/cwa-app-android
-
 [cwa-wishlist]: https://github.com/corona-warn-app/cwa-wishlist
-
 [cwa-website]: https://github.com/corona-warn-app/cwa-website
-
 [cwa-server]: https://github.com/corona-warn-app/cwa-server
-
+[cwa-ppa-server]: https://github.com/corona-warn-app/cwa-ppa-server
 [cwa-verification-server]: https://github.com/corona-warn-app/cwa-verification-server
-
 [cwa-verification-portal]: https://github.com/corona-warn-app/cwa-verification-portal
-
 [cwa-verification-iam]: https://github.com/corona-warn-app/cwa-verification-iam
-
 [cwa-testresult-server]: https://github.com/corona-warn-app/cwa-testresult-server
+[cwa-log-upload]: https://github.com/corona-warn-app/cwa-log-upload
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ become part of its developer community.
 
 A list of all public repositories from the Corona-Warn-App can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/README.md#repositories).
 
-
 ## Licensing
 
 Copyright (c) 2020 Deutsche Telekom AG.

--- a/README.md
+++ b/README.md
@@ -155,33 +155,8 @@ become part of its developer community.
 
 ## Repositories
 
-| Repository                | Description                                                                  |
-| ------------------------- | ---------------------------------------------------------------------------- |
-| [cwa-documentation]       | Project overview, general documentation, and white papers.                   |
-| [cwa-app-ios]             | Native iOS app using the Apple/Google exposure notification API.             |
-| [cwa-app-android]         | Native Android app using the Apple/Google exposure notification API.         |
-| [cwa-wishlist]            | Community feature requests.                                                  |
-| [cwa-website]             | The official website for the Corona-Warn-App.                                |
-| [cwa-server]              | Backend implementation for the Apple/Google exposure notification API.       |
-| [cwa-ppa-server]          | Backend implementation for the privacy-preserving analytics server.          |
-| [cwa-verification-server] | Backend implementation of the verification process.                          |
-| [cwa-verification-portal] | The portal to interact with the verification server.                         |
-| [cwa-verification-iam]    | The identity and access management to interact with the verification server. |
-| [cwa-testresult-server]   | Receives the test results from connected laboratories.                       |
-| [cwa-log-upload]          | The log upload service is the counterpart of the log upload in the app.      |
+A list of all public repositories from the Corona-Warn-App can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/README.md#repositories).
 
-[cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation
-[cwa-app-ios]: https://github.com/corona-warn-app/cwa-app-ios
-[cwa-app-android]: https://github.com/corona-warn-app/cwa-app-android
-[cwa-wishlist]: https://github.com/corona-warn-app/cwa-wishlist
-[cwa-website]: https://github.com/corona-warn-app/cwa-website
-[cwa-server]: https://github.com/corona-warn-app/cwa-server
-[cwa-ppa-server]: https://github.com/corona-warn-app/cwa-ppa-server
-[cwa-verification-server]: https://github.com/corona-warn-app/cwa-verification-server
-[cwa-verification-portal]: https://github.com/corona-warn-app/cwa-verification-portal
-[cwa-verification-iam]: https://github.com/corona-warn-app/cwa-verification-iam
-[cwa-testresult-server]: https://github.com/corona-warn-app/cwa-testresult-server
-[cwa-log-upload]: https://github.com/corona-warn-app/cwa-log-upload
 
 ## Licensing
 


### PR DESCRIPTION
This PR discontinues the [repository table](https://github.com/corona-warn-app/cwa-log-upload#repositories) in the README here, instead the README now links to the [table](https://github.com/corona-warn-app/cwa-documentation/blob/master/README.md#repositories) in the [documentation repository](https://github.com/corona-warn-app/cwa-documentation).
This will make it easier to update the list with newly created repositories.