### PR TITLE
Correct a link in the issue template ("Other")

### DIFF
--- a/.github/ISSUE_TEMPLATE/05_other.md
+++ b/.github/ISSUE_TEMPLATE/05_other.md
@@ -8,5 +8,5 @@ labels: other
 Thanks for contributing to the project!
 Before opening a new issue, please make sure that we do not have any duplicates already open. 
 You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
-Also, be sure to check our readme first: https://github.com/corona-warn-app/cwa-verification-server
+Also, be sure to check our readme first: https://github.com/corona-warn-app/cwa-log-upload
 -->


### PR DESCRIPTION
This PR corrects a copy/paste issue in the issue template "Other", there was a link to the README.md of the verification server, instead of the README.md here.