### PR TITLE
Remove too verbose log message

### DIFF
--- a/src/main/java/app/coronawarn/logupload/controller/LogUploadApiController.java
+++ b/src/main/java/app/coronawarn/logupload/controller/LogUploadApiController.java
@@ -106,7 +106,7 @@ public class LogUploadApiController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "OTP is required for log upload.");
         }
 
-        log.info("Got file: {}, {}", file.getOriginalFilename(), file.getSize());
+        log.info("Got file with size of {}", file.getSize());
 
         LogEntity logEntity;
 

--- a/src/main/java/app/coronawarn/logupload/controller/LogUploadPortalController.java
+++ b/src/main/java/app/coronawarn/logupload/controller/LogUploadPortalController.java
@@ -108,7 +108,7 @@ public class LogUploadPortalController {
     public String search(HttpServletRequest request, Model model, @ModelAttribute(ATTR_LOG_ID) String logId) {
         addUserDetailsToModel(request, model);
 
-        log.info("Got id {}", logId);
+        log.info("Searching log by id");
 
         LogEntity logEntity = logService.getLogEntity(logId);
 


### PR DESCRIPTION
This PR removes 2 too verbose log messages which could allow an attacker to inject bad log messages.

This PR closes #24