### PR TITLE
Bump copyright year in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A list of all public repositories from the Corona-Warn-App can be found [here](h
 
 ## Licensing
 
-Copyright (c) 2020 Deutsche Telekom AG.
+Copyright (c) 2020-2022 Deutsche Telekom AG.
 
 Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with
 the License.


### PR DESCRIPTION
This commit bumps the copyright year in the README.md file.

Happy new year! 🎉

### Note

This PR should only be merged once a change to the content of this repository was done. 